### PR TITLE
Add DateUtilsTest

### DIFF
--- a/iridium-server-base/pom.xml
+++ b/iridium-server-base/pom.xml
@@ -59,11 +59,6 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
         </dependency>

--- a/iridium-server-base/pom.xml
+++ b/iridium-server-base/pom.xml
@@ -64,6 +64,11 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>

--- a/iridium-server-base/src/test/java/software/iridium/api/DateUtilsTest.java
+++ b/iridium-server-base/src/test/java/software/iridium/api/DateUtilsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package software.iridium.api;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Calendar;
+import java.util.Date;
+import org.junit.jupiter.api.Test;
+import software.iridium.api.util.DateUtils;
+
+public class DateUtilsTest {
+
+  @Test
+  public void addHoursToCurrentTime_AllGood_FiveHoursAdded() {
+    final var hours = 5;
+
+    final var calendar = Calendar.getInstance();
+    calendar.setTime(new Date());
+    calendar.add(Calendar.HOUR_OF_DAY, hours);
+    final var dateFiveHoursAhead = calendar.getTime();
+
+    Date dateAfterAddingFiveHoursToCurrentTime = DateUtils.addHoursToCurrentTime(hours);
+
+    assertTrue(dateAfterAddingFiveHoursToCurrentTime.getTime() >= dateFiveHoursAhead.getTime());
+  }
+
+  @Test
+  public void addMinutesToCurrentTime_AllGood_FiveMinutesAdded() {
+    final var minutes = 5;
+
+    final var calendar = Calendar.getInstance();
+    calendar.setTime(new Date());
+    calendar.add(Calendar.MINUTE, minutes);
+    final var dateFiveMinutesAhead = calendar.getTime();
+
+    Date dateAfterAddingFiveMinutesToCurrentTime = DateUtils.addMinutesToCurrentTime(minutes);
+
+    assertTrue(dateAfterAddingFiveMinutesToCurrentTime.getTime() >= dateFiveMinutesAhead.getTime());
+  }
+}

--- a/iridium-server-base/src/test/java/software/iridium/api/DateUtilsTest.java
+++ b/iridium-server-base/src/test/java/software/iridium/api/DateUtilsTest.java
@@ -11,40 +11,50 @@
  */
 package software.iridium.api;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Calendar;
 import java.util.Date;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import software.iridium.api.util.DateUtils;
 
+@ExtendWith(MockitoExtension.class)
 public class DateUtilsTest {
+
+  @Mock private Calendar calendarInstanceMock;
 
   @Test
   public void addHoursToCurrentTime_AllGood_FiveHoursAdded() {
-    final var hours = 5;
+    try (MockedStatic<Calendar> calendarMock = Mockito.mockStatic(Calendar.class)) {
+      when(calendarInstanceMock.getTime()).thenReturn(new Date());
+      calendarMock.when(Calendar::getInstance).thenReturn(calendarInstanceMock);
 
-    final var calendar = Calendar.getInstance();
-    calendar.setTime(new Date());
-    calendar.add(Calendar.HOUR_OF_DAY, hours);
-    final var dateFiveHoursAhead = calendar.getTime();
+      final var hours = 5;
+      Date dateAfterAddingFiveHoursToCurrentTime = DateUtils.addHoursToCurrentTime(hours);
 
-    Date dateAfterAddingFiveHoursToCurrentTime = DateUtils.addHoursToCurrentTime(hours);
-
-    assertTrue(dateAfterAddingFiveHoursToCurrentTime.getTime() >= dateFiveHoursAhead.getTime());
+      verify(calendarInstanceMock).add(Calendar.HOUR_OF_DAY, hours);
+      assertNotNull(dateAfterAddingFiveHoursToCurrentTime);
+    }
   }
 
   @Test
   public void addMinutesToCurrentTime_AllGood_FiveMinutesAdded() {
-    final var minutes = 5;
+    try (MockedStatic<Calendar> calendarClassMock = Mockito.mockStatic(Calendar.class)) {
+      when(calendarInstanceMock.getTime()).thenReturn(new Date());
+      calendarClassMock.when(Calendar::getInstance).thenReturn(calendarInstanceMock);
 
-    final var calendar = Calendar.getInstance();
-    calendar.setTime(new Date());
-    calendar.add(Calendar.MINUTE, minutes);
-    final var dateFiveMinutesAhead = calendar.getTime();
+      final var minutes = 5;
+      Date dateAfterAddingFiveMinutesToCurrentTime = DateUtils.addMinutesToCurrentTime(minutes);
 
-    Date dateAfterAddingFiveMinutesToCurrentTime = DateUtils.addMinutesToCurrentTime(minutes);
-
-    assertTrue(dateAfterAddingFiveMinutesToCurrentTime.getTime() >= dateFiveMinutesAhead.getTime());
+      verify(calendarInstanceMock).add(Calendar.MINUTE, minutes);
+      assertNotNull(dateAfterAddingFiveMinutesToCurrentTime);
+    }
   }
 }

--- a/iridium-server-base/src/test/java/software/iridium/api/DateUtilsTest.java
+++ b/iridium-server-base/src/test/java/software/iridium/api/DateUtilsTest.java
@@ -32,9 +32,9 @@ public class DateUtilsTest {
 
   @Test
   public void addHoursToCurrentTime_AllGood_FiveHoursAdded() {
-    try (MockedStatic<Calendar> calendarMock = Mockito.mockStatic(Calendar.class)) {
+    try (MockedStatic<Calendar> calendarClassMock = Mockito.mockStatic(Calendar.class)) {
       when(calendarInstanceMock.getTime()).thenReturn(new Date());
-      calendarMock.when(Calendar::getInstance).thenReturn(calendarInstanceMock);
+      calendarClassMock.when(Calendar::getInstance).thenReturn(calendarInstanceMock);
 
       final var hours = 5;
       Date dateAfterAddingFiveHoursToCurrentTime = DateUtils.addHoursToCurrentTime(hours);


### PR DESCRIPTION
Add `DateUtilsTest` for the `DateUtils` class inside `iridium-server-base`.

I've introduced `mockito-inline` as a test-dependency to be able to statically mock the `Calendar` class to verify that hours, respectively minutes are added.