### PR TITLE
Making the redirect to the management console work from within docker compose.

### DIFF
--- a/site/docs/2.-getting-started/2.stand-up-local.md
+++ b/site/docs/2.-getting-started/2.stand-up-local.md
@@ -23,7 +23,11 @@ $ git clone git@github.com:IridiumIdentity/iridium.git
 ```shell
 $ cd iridium
 ```
-Stand up mariadb, the latest version of the core iridium server, and the fake smtp server
+Before running the compose command below be sure to set the environment variable HOST_INTERNAL.  This ip address should be set to whatever your default gateway is.  This is typically the ip address of your router on a home network.  The address below is just an example. 
+```shell
+export HOST_INTERNAL=192.168.1.x
+```
+Stand up mariadb, the latest version of the core iridium server
 ```shell
 $ docker compose -f tools/schedulers/compose/local-iridium-compose.yml up -d
 ```

--- a/tools/schedulers/compose/local-iridium-compose.yml
+++ b/tools/schedulers/compose/local-iridium-compose.yml
@@ -16,6 +16,8 @@ services:
   iridium:
     image: iridiumidentity/iridium-core-server:latest
     container_name: iridium
+    depends_on: 
+      - mariadb
     restart: always
     pull_policy: always
     ports:
@@ -47,6 +49,8 @@ services:
       - SPRING_MAIL_FROM_ADDRESS=noreply@yourdomain.com
       - SPRING_THYMELEAF_PREFIX=classpath:/templates/
       - SPRING_THYMELEAF_SUFFIX=.html
+    extra_hosts:
+      - "host.docker.internal:${HOST_INTERNAL}"
 
     networks:
       - iridium


### PR DESCRIPTION
This makes use of a construct called host.docker.internal I think this is cross platform but we will need to verify this. The host docker internal directive is what allows bridging the network to the host network without leveraging something like NAT.

Longer term we may want to think about HAPROXY or NGinx or one of those.

I also made the containers depend on one another.  So the iridium container now depends on the mariadb container.  Without this on my machine the api was coming up first and it was causing quite a few exceptions.