### PR TITLE
Removal of the warnings.

### DIFF
--- a/iridium-cli/pom.xml
+++ b/iridium-cli/pom.xml
@@ -80,6 +80,7 @@
                             <descriptors>
                                 <descriptor>src/assembly/bin.xml</descriptor>
                             </descriptors>
+                            <tarLongFileMode>gnu</tarLongFileMode>
                         </configuration>
                     </execution>
 


### PR DESCRIPTION
This pull removes the warnings that were being generated by the maven assembly plugin. 